### PR TITLE
Tests name over LoadSpinner component was inverted

### DIFF
--- a/src/app/shared-components/__test__/LoadSpinner.spec.js
+++ b/src/app/shared-components/__test__/LoadSpinner.spec.js
@@ -3,12 +3,12 @@ import { Wrap } from '../../../../test/helpers'
 
 describe('LoadSpinner.vue', () => {
 
-  it('shows loading', () => {
+  it('does not show loading', () => {
     const wrapper = Wrap(LoadSpinner).withProps({ isLoading: false }).mount()
     expect(wrapper.text()).not.toContain('Loading...')
   })
 
-  it('does not show loading', () => {
+  it('shows loading', () => {
     const wrapper = Wrap(LoadSpinner).withProps({ isLoading: true }).mount()
 
     expect(wrapper.text()).toContain('Loading...')


### PR DESCRIPTION
I think tests name over LoadSpinner component was inverted. 